### PR TITLE
#9 Token not returning

### DIFF
--- a/XeroNetStandardApp/IO/LocalStorageTokenIO.cs
+++ b/XeroNetStandardApp/IO/LocalStorageTokenIO.cs
@@ -52,11 +52,8 @@ namespace XeroNetStandardApp.IO
         /// <param name="xeroToken">Xero OAuth2 token to save</param>
         public void StoreToken(XeroOAuth2Token xeroToken)
         {
-            if (File.Exists(TokenFilePath))
-            {
-                var serializedToken = JsonSerializer.Serialize(xeroToken);
-                File.WriteAllText(TokenFilePath, serializedToken);
-            }
+            var serializedToken = JsonSerializer.Serialize(xeroToken);
+            File.WriteAllText(TokenFilePath, serializedToken);
         }
 
         /// <summary>


### PR DESCRIPTION
This issue is caused by `xerotoken.json` not existing by default and `StoreToken` only persisting the returned token if it does. Since `File.WriteAllText` creates the file if it doesn't already exist or overwrites it if it does, removing the `File.Exists` check means that it will create/update the file as expected and avoid the issue of a missing `refresh_token`.